### PR TITLE
Update minimum CMake required version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.16.3)
 
 set (ROCKET_VERSION "1.0.0")
 set (ALLOWED_BUILD_TYPES "Debug" "Release")


### PR DESCRIPTION
I have tested that the system builds perfectly with 3.16.3, so this can be useful for people with systems like mine (ubuntu 20.10)